### PR TITLE
Make example from README.md pasteable into a REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Here is an output sample:
 ```julia
 julia> using Llama2
 
+julia> download("https://huggingface.co/karpathy/tinyllamas/resolve/main/stories42M.bin", "stories42M.bin")
+"stories42M.bin"
+
+julia> download("https://raw.githubusercontent.com/karpathy/llama2.c/b4bb47bb7baf0a5fb98a131d80b4e1a84ad72597/tokenizer.bin", "tokenizer.bin")
+"tokenizer.bin"
+
 julia> model = load_ggml_model("llama-2-7b-chat.ggmlv3.q4_K_S.bin");
 
 julia> sample(model, "The Julia programming language is")

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Here is an output sample from the 42M tinyllama model:
 ```julia
 julia> using Llama2
 
+julia> download("https://huggingface.co/karpathy/tinyllamas/resolve/main/stories42M.bin", "stories42M.bin")
+"stories42M.bin"
+
+julia> download("https://raw.githubusercontent.com/karpathy/llama2.c/b4bb47bb7baf0a5fb98a131d80b4e1a84ad72597/tokenizer.bin", "tokenizer.bin")
+"tokenizer.bin"
+
 julia> model = load_karpathy_model("stories42M.bin", "tokenizer.bin");
 
 julia> sample(model, "Tim was happy."; temperature = 0.8f0)
@@ -40,12 +46,6 @@ A compatible Llama2 7B model can be downloaded from https://huggingface.co/TheBl
 Here is an output sample:
 ```julia
 julia> using Llama2
-
-julia> download("https://huggingface.co/karpathy/tinyllamas/resolve/main/stories42M.bin", "stories42M.bin")
-"stories42M.bin"
-
-julia> download("https://raw.githubusercontent.com/karpathy/llama2.c/b4bb47bb7baf0a5fb98a131d80b4e1a84ad72597/tokenizer.bin", "tokenizer.bin")
-"tokenizer.bin"
 
 julia> model = load_ggml_model("llama-2-7b-chat.ggmlv3.q4_K_S.bin");
 


### PR DESCRIPTION
While the existing download instructions are workable, a direct link embedded in pastable Julia code is easier to use.